### PR TITLE
Update Zebra to handle Stripe's new webhooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ zebra_webhook_recurring_payment_succeeded.connect(update_last_invoice_date)
 Stripe recently updated their webhok implementation (see https://stripe.com/blog/webhooks). Zebra includes an implementation of the new system.
 
 * Include the zebra urls
-* Update your stripe account to point to your webhook URL (aka https://www.mysite.com/zebra/webhooks2)
+* Update your stripe account to point to your webhook URL (aka https://www.mysite.com/zebra/webhooks/v2/)
 * Plug into any webhook signals you care about.  
 
 Zebra provides:

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Usage
 	INSTALLED_APPS += ("zebra",)
 	STRIPE_SECRET = "YOUR-SECRET-API-KEY"
 	STRIPE_PUBLISHABLE = "YOUR-PUBLISHABLE-API-KEY"
-
-	# Set any optional settings (below)
-	```
+    # Set any optional settings (below)
+    ```
 
 3. (optional) `./manage.py syncdb` if you have `ZEBRA_ENABLE_APP = True`
 
@@ -59,6 +58,7 @@ Zebra handles all the webhooks that stripe sends back and calls a set of signals
 * Update your stripe account to point to your webhook URL (aka https://www.mysite.com/zebra/webhooks)
 * Plug into any webhook signals you care about.  
 
+**Note: The initial Stripe webhook system is being deprecated. See below for a description of Zebra's support for the new system.**
 
 Zebra provides:
 
@@ -89,6 +89,51 @@ def update_last_invoice_date(sender, **kwargs):
 zebra_webhook_recurring_payment_succeeded.connect(update_last_invoice_date)
 ```
 
+### Webhooks Update ###
+
+Stripe recently updated their webhok implementation (see https://stripe.com/blog/webhooks). Zebra includes an implementation of the new system.
+
+* Include the zebra urls
+* Update your stripe account to point to your webhook URL (aka https://www.mysite.com/zebra/webhooks2)
+* Plug into any webhook signals you care about.  
+
+Zebra provides:
+
+* `zebra_webhook_charge_succeeded`
+* `zebra_webhook_charge_failed`
+* `zebra_webhook_charge_refunded`
+* `zebra_webhook_charge_disputed`
+* `zebra_webhook_customer_created`
+* `zebra_webhook_customer_updated`
+* `zebra_webhook_customer_deleted`
+* `zebra_webhook_customer_subscription_created`
+* `zebra_webhook_customer_subscription_updated`
+* `zebra_webhook_customer_subscription_deleted`
+* `zebra_webhook_customer_subscription_trial_will_end`
+* `zebra_webhook_customer_discount_created`
+* `zebra_webhook_customer_discount_updated`
+* `zebra_webhook_customer_discount_deleted`
+* `zebra_webhook_invoice_created`
+* `zebra_webhook_invoice_updated`
+* `zebra_webhook_invoice_payment_succeeded`
+* `zebra_webhook_invoice_payment_failed`
+* `zebra_webhook_invoiceitem_created`
+* `zebra_webhook_invoiceitem_updated`
+* `zebra_webhook_invoiceitem_deleted`
+* `zebra_webhook_plan_created`
+* `zebra_webhook_plan_updated`
+* `zebra_webhook_plan_deleted`
+* `zebra_webhook_coupon_created`
+* `zebra_webhook_coupon_updated`
+* `zebra_webhook_coupon_deleted`
+* `zebra_webhook_transfer_created`
+* `zebra_webhook_transfer_failed`
+* `zebra_webhook_ping`
+
+Zebra also provides an easy map of all the signals as `zebra.signals.WEBHOOK_MAP`, which maps events (`charge_succeeded`) to the Zebra signal (`zebra_webhook_charge_succeeded`). To assign a handler to all the signals that zebra sends, for example, loop over the items in the map:
+
+    for event_key, webhook_signal in WEBHOOK_MAP.iteritems():
+        webhook_signal.connect(webhook_logger)
 
 
 ## Forms ##

--- a/zebra/signals.py
+++ b/zebra/signals.py
@@ -1,6 +1,5 @@
 import django.dispatch
 
-
 WEBHOOK_ARGS = ["customer", "full_json"]
 
 zebra_webhook_recurring_payment_failed = django.dispatch.Signal(providing_args=WEBHOOK_ARGS)
@@ -9,3 +8,70 @@ zebra_webhook_recurring_payment_succeeded = django.dispatch.Signal(providing_arg
 zebra_webhook_subscription_trial_ending = django.dispatch.Signal(providing_args=WEBHOOK_ARGS)
 zebra_webhook_subscription_final_payment_attempt_failed = django.dispatch.Signal(providing_args=WEBHOOK_ARGS)
 zebra_webhook_subscription_ping_sent = django.dispatch.Signal(providing_args=[])
+
+# v2 webhooks
+WEBHOOK2_ARGS = ["full_json"]
+
+zebra_webhook_charge_succeeded = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_charge_failed = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_charge_refunded = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_charge_disputed = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_subscription_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_subscription_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_subscription_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_subscription_trial_will_end = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_discount_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_discount_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_customer_discount_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoice_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoice_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoice_payment_succeeded = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoice_payment_failed = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoiceitem_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoiceitem_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_invoiceitem_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_plan_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_plan_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_plan_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_coupon_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_coupon_updated = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_coupon_deleted = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_transfer_created = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_transfer_failed = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+zebra_webhook_ping = django.dispatch.Signal(providing_args=WEBHOOK2_ARGS)
+
+WEBHOOK_MAP = {
+    'charge_succeeded': zebra_webhook_charge_succeeded,
+    'charge_failed': zebra_webhook_charge_failed,
+    'charge_refunded': zebra_webhook_charge_refunded,
+    'charge_disputed': zebra_webhook_charge_disputed,
+    'customer_created': zebra_webhook_customer_created,
+    'customer_updated': zebra_webhook_customer_updated,
+    'customer_deleted': zebra_webhook_customer_deleted,
+    'customer_subscription_created': zebra_webhook_customer_subscription_created,
+    'customer_subscription_updated': zebra_webhook_customer_subscription_updated,
+    'customer_subscription_deleted': zebra_webhook_customer_subscription_deleted,
+    'customer_subscription_trial_will_end': zebra_webhook_customer_subscription_trial_will_end,
+    'customer_discount_created': zebra_webhook_customer_discount_created,
+    'customer_discount_updated': zebra_webhook_customer_discount_updated,
+    'customer_discount_deleted': zebra_webhook_customer_discount_deleted,
+    'invoice_created': zebra_webhook_invoice_created,
+    'invoice_updated': zebra_webhook_invoice_updated,
+    'invoice_payment_succeeded': zebra_webhook_invoice_payment_succeeded,
+    'invoice_payment_failed': zebra_webhook_invoice_payment_failed,
+    'invoiceitem_created': zebra_webhook_invoiceitem_created,
+    'invoiceitem_updated': zebra_webhook_invoiceitem_updated,
+    'invoiceitem_deleted': zebra_webhook_invoiceitem_deleted,
+    'plan_created': zebra_webhook_plan_created,
+    'plan_updated': zebra_webhook_plan_updated,
+    'plan_deleted': zebra_webhook_plan_deleted,
+    'coupon_created': zebra_webhook_coupon_created,
+    'coupon_updated': zebra_webhook_coupon_updated,
+    'coupon_deleted': zebra_webhook_coupon_deleted,
+    'transfer_created': zebra_webhook_transfer_created,
+    'transfer_failed': zebra_webhook_transfer_failed,
+    'ping': zebra_webhook_ping,
+}

--- a/zebra/urls.py
+++ b/zebra/urls.py
@@ -4,4 +4,5 @@ from zebra import views
 
 urlpatterns = patterns('',
     url(r'webhooks/$',     views.webhooks,          name='webhooks'),
+    url(r'webhooks2/$',     views.webhooks2,          name='webhooks2'),
 )

--- a/zebra/urls.py
+++ b/zebra/urls.py
@@ -4,5 +4,5 @@ from zebra import views
 
 urlpatterns = patterns('',
     url(r'webhooks/$',     views.webhooks,          name='webhooks'),
-    url(r'webhooks2/$',     views.webhooks2,          name='webhooks2'),
+    url(r'webhooks/v2/$',     views.webhooks_v2,          name='webhooks_v2'),
 )

--- a/zebra/views.py
+++ b/zebra/views.py
@@ -6,6 +6,8 @@ from zebra.conf import options
 from zebra.signals import *
 from django.views.decorators.csrf import csrf_exempt
 
+import logging
+log = logging.getLogger("zebra.%s" % __name__)
 
 stripe.api_key = options.STRIPE_SECRET
 
@@ -50,5 +52,22 @@ def webhooks(request):
 
     else:
         return HttpResponse(status=400)
+
+    return HttpResponse(status=200)
+
+@csrf_exempt
+def webhooks2(request):
+    """
+    Handles all known webhooks from stripe, and calls signals.
+    Plug in as you need.
+    """
+    if request.method != "POST":
+        return HttpResponse("Invalid Request.", status=400)
+
+    event_json = simplejson.loads(request.raw_post_data)
+    event_key = event_json['type'].replace('.', '_')
+
+    if event_key in WEBHOOK_MAP:
+        WEBHOOK_MAP[event_key].send(sender=None, full_json=event_json)
 
     return HttpResponse(status=200)

--- a/zebra/views.py
+++ b/zebra/views.py
@@ -56,7 +56,7 @@ def webhooks(request):
     return HttpResponse(status=200)
 
 @csrf_exempt
-def webhooks2(request):
+def webhooks_v2(request):
     """
     Handles all known webhooks from stripe, and calls signals.
     Plug in as you need.


### PR DESCRIPTION
Stripe recently updated their webhooks[1] such that they send a webhook post for many different events[2]. I've written an implementation of these new webhooks for Zebra.

I've maintained backwards compatibility so that anyone using the old webhook system can continue to do so until it's retired. The new webhooks view defaults to `/zebra/webhooks2/`.

`zebra.signals` contains the new signals, and also provides a `WEBHOOKS_MAP` structure that maps events keys to signals. When an event arrives from Stripe, the json structure has a key in it called "type", that is now a dot-delimited name, following the 'resource'.'event' scheme. So `invoice_ready` is now `invoice.created`. The new webhooks2 endpoint first converts `invoice.created` to `invoice_created` then uses this map to lookup the correct signal:

``` python
    event_json = simplejson.loads(request.raw_post_data)
    event_key = event_json['type'].replace('.', '_')

    if event_key in WEBHOOK_MAP:
        WEBHOOK_MAP[event_key].send( sender=None, 
            full_json=event_json )
```

In the app using Zebra, this map can also be used to connect webhooks:

``` python
from zebra.signals import *

def webhook_logger(sender, full_json, **kwargs):
    log.info ('STRIPE EVENT: %s DATA: \n%s' % (full_json['type'], repr(full_json)))

zebra_webhook_invoice_created.connect(webhook_logger)
# same thing
WEBHOOK_MAP['invoice_created'].connect(webhook_logger)
```

I'm not married to the implementation, but it seemed clean and it's working. Would love to hear your thoughts!

--Steve

[1] https://stripe.com/blog/webhooks
[2] https://stripe.com/docs/api#event_types
