### PR TITLE
Readme: Typo Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Usage
 * `ZEBRA_CUSTOMER_MODEL` 
 	The app+model string for the model that implements the StripeCustomerMixin. ie `"myapp.MyCustomer"`.  If `ZEBRA_ENABLE_APP` is true, defaults to `"zebra.Customer"`. 
 * `ZEBRA_AUTO_CREATE_STRIPE_CUSTOMERS` 
-	Defaults to `True`.  Automatically creates a stripe customer obect on stripe_customer access, if one doesn't exist.
+	Defaults to `True`.  Automatically creates a stripe customer object on stripe_customer access, if one doesn't exist.
 
 
 ## Webhooks ##


### PR DESCRIPTION
Fixed 'obect' in the README
