### PR TITLE
Make templatetags zebra_card_form and zebra_head_and_stripe_key work in formwizard

### DIFF
--- a/zebra/templatetags/zebra_tags.py
+++ b/zebra/templatetags/zebra_tags.py
@@ -9,16 +9,18 @@ from zebra.conf import options
 
 
 register = template.Library()
-
 def _set_up_zebra_form(context):
     if not "zebra_form" in context:
         if "form" in context:
             context["zebra_form"] = context["form"]
+        elif "form" in context["wizard"]:
+            context["zebra_form"] = context["wizard"]["form"]
         else:
             raise Exception, "Missing stripe form."
-    context["STRIPE_PUBLISHABLE"] = options.STRIPE_PUBLISHABLE
-    return context
 
+    context["STRIPE_PUBLISHABLE"] = options.STRIPE_PUBLISHABLE
+
+    return context
 
 @register.inclusion_tag('zebra/_stripe_js_and_set_stripe_key.html', takes_context=True)
 def zebra_head_and_stripe_key(context):


### PR DESCRIPTION
zebra_card_form and zebra_head_and_stripe_key need 'form' in the context.  However, if a form is being used inside a formwizard, 'form' is not in the context.  'Wizard' is in the context, and 'form' is inside 'wizard.' This small patch checks for the existence of 'form' in 'wizard' and assigns zebra_form to it.
