### PR TITLE
Updated webhook processing to be compatible with Django 1.6.

### DIFF
--- a/zebra/views.py
+++ b/zebra/views.py
@@ -64,7 +64,12 @@ def webhooks_v2(request):
     if request.method != "POST":
         return HttpResponse("Invalid Request.", status=400)
 
-    event_json = simplejson.loads(request.raw_post_data)
+    try:
+        event_json = simplejson.loads(request.body)
+    except AttributeError:
+        # Backwords compatibility
+        # Prior to Django 1.4, request.body was named request.raw_post_data
+        event_json = simplejson.loads(request.raw_post_data)
     event_key = event_json['type'].replace('.', '_')
 
     if event_key in WEBHOOK_MAP:


### PR DESCRIPTION
This is a fix for issue #30.

It is backwords compatible with Django < 1.4.
