### PR TITLE
Fixed django.utils.simplejson deprecation warning

### DIFF
--- a/zebra/views.py
+++ b/zebra/views.py
@@ -1,5 +1,9 @@
 from django.http import HttpResponse
-from django.utils import simplejson
+try:
+    import json as simplejson
+except:
+    from django.utils import simplejson
+    
 from django.db.models import get_model
 import stripe
 from zebra.conf import options


### PR DESCRIPTION
Fixed deprecation warning for django1.6 with try/except import json as simplejson
Warning was:
lib/python2.7/site-packages/zebra/views.py:5: DeprecationWarning: django.utils.simplejson is deprecated; use json instead.
  from django.utils import simplejson
