### PR TITLE
use {box-sizing: content-box} for input elements

### DIFF
--- a/zebra/static/zebra/card-form.css
+++ b/zebra/static/zebra/card-form.css
@@ -1,9 +1,12 @@
 #id_card_number {
     width: 15ex;
+    box-sizing: content-box;
 }
 #id_card_cvv {
     width: 3ex;
+    box-sizing: content-box;
 }
 #id_card_expiry_year {
     width: 10ex;
+    box-sizing: content-box;
 }


### PR DESCRIPTION
Since you're using relative units for the width need to make sure any padding is not included in the width measurement. content-box is the default in some browsers but it is frequently normalized to border-box in CSS frameworks.
