### PR TITLE
Allow css classes to come from self.attrs without being overwritten.

### DIFF
--- a/zebra/forms.py
+++ b/zebra/forms.py
@@ -2,6 +2,8 @@ from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.dates import MONTHS
 
+from six import iteritems
+
 from zebra.conf import options
 from zebra.widgets import NoNameSelect, NoNameTextInput
 
@@ -23,7 +25,7 @@ class StripePaymentForm(CardForm):
         self.fields['card_cvv'].label = "Card CVC"
         self.fields['card_cvv'].help_text = "Card Verification Code; see rear of card."
         months = [ (m[0], u'%02d - %s' % (m[0], unicode(m[1])))
-                    for m in sorted(MONTHS.iteritems()) ]
+                    for m in sorted(iteritems(MONTHS)) ]
         self.fields['card_expiry_month'].choices = months
 
     card_number = forms.CharField(required=False, max_length=20,
@@ -31,6 +33,6 @@ class StripePaymentForm(CardForm):
     card_cvv = forms.CharField(required=False, max_length=4,
         widget=NoNameTextInput())
     card_expiry_month = forms.ChoiceField(required=False, widget=NoNameSelect(),
-        choices=MONTHS.iteritems())
+        choices=iteritems(MONTHS))
     card_expiry_year = forms.ChoiceField(required=False, widget=NoNameSelect(),
         choices=options.ZEBRA_CARD_YEARS_CHOICES)

--- a/zebra/forms.py
+++ b/zebra/forms.py
@@ -24,7 +24,7 @@ class StripePaymentForm(CardForm):
         super(StripePaymentForm, self).__init__(*args, **kwargs)
         self.fields['card_cvv'].label = "Card CVC"
         self.fields['card_cvv'].help_text = "Card Verification Code; see rear of card."
-        months = [ (m[0], u'%02d - %s' % (m[0], unicode(m[1])))
+        months = [ (m[0], u'%02d - %s' % (m[0], str(m[1])))
                     for m in sorted(iteritems(MONTHS)) ]
         self.fields['card_expiry_month'].choices = months
 

--- a/zebra/templatetags/zebra_tags.py
+++ b/zebra/templatetags/zebra_tags.py
@@ -15,7 +15,7 @@ def _set_up_zebra_form(context):
         if "form" in context:
             context["zebra_form"] = context["form"]
         else:
-            raise Exception, "Missing stripe form."
+            raise Exception("Missing stripe form.")
     context["STRIPE_PUBLISHABLE"] = options.STRIPE_PUBLISHABLE
     return context
 

--- a/zebra/templatetags/zebra_tags.py
+++ b/zebra/templatetags/zebra_tags.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse
 from django import template
 from django.template.loader import render_to_string
-from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 

--- a/zebra/widgets.py
+++ b/zebra/widgets.py
@@ -5,13 +5,22 @@ from django.utils.safestring import mark_safe
 class NoNameWidget(object):
 
     def _update_to_noname_class_name(self, name, kwargs_dict):
+        name_class = name.replace("_", "-")
+
+        current_classes = ''
+        if "class" in self.attrs:
+            current_classes = self.attrs["class"]
+
         if "attrs" in kwargs_dict:
             if "class" in kwargs_dict["attrs"]:
-                kwargs_dict["attrs"]["class"] += " %s" % (name.replace("_", "-"), )
+                kwargs_dict["attrs"]["class"] += (" %s" % name.replace("_", "-"))
             else:
                 kwargs_dict["attrs"].update({'class': name.replace("_", "-")})
         else:
             kwargs_dict["attrs"] = {'class': name.replace("_", "-")}
+
+        if current_classes != '':
+            kwargs_dict["attrs"]["class"] += ' %s' % current_classes
 
         return kwargs_dict
 


### PR DESCRIPTION
I am using a bootstrap form mixin which includes code similar to this

```
class BootstrapForm(object):
    def __init__(self, *args, **kwargs):
        super(BootstrapForm, self).__init__(*args, **kwargs)
        for bfield in self:
            field = self.fields[bfield.name]
            classes = ['form-control']
            if 'class' in field.widget.attrs:
                classes.append(field.widget.attrs['class'])
            field.widget.attrs.update(
                {'class' : ' '.join(classes)}
            )
```

It depends on the value of field.widget.attrs['class'] being propagated to the rendered widget.

One could argue that Django should be doing the combining for us, but it doesn't, for now this works, and I don't believe will cause any other issues.
