### PR TITLE
Request that the browser disable autocomplete for credit card fields

### DIFF
--- a/zebra/forms.py
+++ b/zebra/forms.py
@@ -27,9 +27,9 @@ class StripePaymentForm(CardForm):
         self.fields['card_expiry_month'].choices = months
 
     card_number = forms.CharField(required=False, max_length=20,
-        widget=NoNameTextInput())
+        widget=NoNameTextInput(attrs={'autocomplete': 'off'}))
     card_cvv = forms.CharField(required=False, max_length=4,
-        widget=NoNameTextInput())
+        widget=NoNameTextInput(attrs={'autocomplete': 'off'}))
     card_expiry_month = forms.ChoiceField(required=False, widget=NoNameSelect(),
         choices=MONTHS.iteritems())
     card_expiry_year = forms.ChoiceField(required=False, widget=NoNameSelect(),


### PR DESCRIPTION
Hello, this uses the [HTML `autocomplete` attribute](http://www.w3.org/wiki/HTML/Elements/input/text) to prevent browsers from displaying a history of previously entered credit card numbers and CVCs. Some browsers (e.g. Chrome) must have a heuristic to disable autocomplete for form fields whose names match a certain pattern, but others do not and record sensitive data.

Thanks for your consideration.
