### PR TITLE
django.conf.urls.patterns is deprecated

### DIFF
--- a/zebra/urls.py
+++ b/zebra/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from zebra import views
 
-urlpatterns = patterns('',
+urlpatterns = (
     url(r'webhooks/$',     views.webhooks,          name='webhooks'),
     url(r'webhooks/v2/$',     views.webhooks_v2,          name='webhooks_v2'),
 )

--- a/zebra_sample_project/marty/urls.py
+++ b/zebra_sample_project/marty/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls.defaults import *
+from django.conf.urls.defaults import url
 from marty import views
 
-urlpatterns = patterns('',          
+urlpatterns = (
     url(r'update$',     views.update,          name='update'),
 )

--- a/zebra_sample_project/urls.py
+++ b/zebra_sample_project/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls.defaults import include, url
 
-urlpatterns = patterns('',
+urlpatterns = (
     url(r'zebra/',   include('zebra.urls',  namespace="zebra",  app_name='zebra') ),
     url(r'',         include('marty.urls',  namespace="marty",  app_name='marty') ),
 )


### PR DESCRIPTION
Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
