### PR TITLE
Updated to support django 1.8

### DIFF
--- a/zebra/views.py
+++ b/zebra/views.py
@@ -3,8 +3,14 @@ try:
     import json as simplejson
 except:
     from django.utils import simplejson
-    
-from django.db.models import get_model
+
+try:
+  from django.apps import apps
+  get_model = apps.get_model
+except ImportError:    
+  # django < 1.8
+  from django.db.models import get_model
+
 import stripe
 from zebra.conf import options
 from zebra.signals import *


### PR DESCRIPTION
django.db.models no longer contains get_model as of 1.8, it has been moved to django.apps. 
