### PR TITLE
docs: Fix simple typo, intstead -> instead

### DIFF
--- a/zebra_sample_project/settings.py
+++ b/zebra_sample_project/settings.py
@@ -1,6 +1,6 @@
 # Django settings for zebra_sample_project project.
 
-# Custom path to include zebra from this repo, intstead of pip installing itself.
+# Custom path to include zebra from this repo, instead of pip installing itself.
 import sys
 from os.path import abspath, dirname, join
 sys.path.insert(0, join(abspath(dirname(__file__)), "../"))


### PR DESCRIPTION
There is a small typo in zebra_sample_project/settings.py.

Should read `instead` rather than `intstead`.

